### PR TITLE
ilkely and ilkley -> likely

### DIFF
--- a/codespell_lib/data/dictionary.txt
+++ b/codespell_lib/data/dictionary.txt
@@ -31668,6 +31668,8 @@ ileagle->illegal
 ilegal->illegal
 ilegle->illegal
 iligal->illegal
+ilkley->likely
+ilkely->likely
 illegimacy->illegitimacy
 illegitmate->illegitimate
 illess->illness


### PR DESCRIPTION
We has `ilkley` in our codebase as a typo for likely.

The only problem I see is there is a town called Ilkley in Yorkshire.